### PR TITLE
Fix bug in OSX when adding new objects to Library

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -291,11 +291,11 @@ class OPS_Save_Selected_Object_to_Category(Operator):
         import subprocess
 
         script = object_utils.save_object_script(filepath, obj.name, blend_path)
-        subprocess.call(bpy.app.binary_path + ' -b --python "' + script + '"')
+        subprocess.call([bpy.app.binary_path, '-b', '--python', script])
 
         if self.create_thumbnail:
             script = object_utils.create_thumbnail_script(blend_path, obj.name, thumbnail_path)
-            subprocess.call(bpy.app.binary_path + ' "' + object_utils.get_thumbnail_path() + '" -b --python "' + script + '"')
+            subprocess.call([bpy.app.binary_path, object_utils.get_thumbnail_path(), '-b', '--python', script])
         return {'FINISHED'}
     
     def invoke(self,context,event):
@@ -343,7 +343,7 @@ class OPS_Create_Thumbnails(Operator):
                 script = object_utils.create_thumbnail_script(obj.filepath, 
                                                               obj.name, 
                                                               os.path.join(fd.get_file_browser_path(context),obj.name))
-                subprocess.call(bpy.app.binary_path + ' "' + object_utils.get_thumbnail_path() + '" -b --python "' + script + '"')
+                subprocess.call([bpy.app.binary_path, object_utils.get_thumbnail_path(), '-b', '--python', script])
         return{'FINISHED'}
         
 class OPS_Load_Objects_From_Category(Operator):


### PR DESCRIPTION
This fix the following error in OSX:

Traceback (most recent call last):
  File "/fluid_designer/Fluid_Designer_2015_R2_OSX/blender.app/Contents/Resources/2.74/scripts/addons/objectlib/operators.py", line 294, in execute
    subprocess.call(bpy.app.binary_path + ' -b --python "' + script + '"')
  File "/fluid_designer/Fluid_Designer_2015_R2_OSX/blender.app/Contents/Resources/2.74/python/lib/python3.4/subprocess.py", line 537, in call
    with Popen(_popenargs, *_kwargs) as p:
  File "/fluid_designer/Fluid_Designer_2015_R2_OSX/blender.app/Contents/Resources/2.74/python/lib/python3.4/subprocess.py", line 858, in **init**
    restore_signals, start_new_session)
  File "/fluid_designer/Fluid_Designer_2015_R2_OSX/blender.app/Contents/Resources/2.74/python/lib/python3.4/subprocess.py", line 1456, in _execute_child
    raise child_exception_type(errno_num, err_msg)
FileNotFoundError: [Errno 2] No such file or directory: '/fluid_designer/Fluid_Designer_2015_R2_OSX/blender.app/Contents/MacOS/blender -b --python "/fluid_designer/Fluid_Designer_2015_R2_OSX/blender.app/Contents/Resources/2.74/scripts/addons/objectlib/temp.py"'
